### PR TITLE
Implement a concurrent distinct queue to be used by the jukebox service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
 			<groupId>org.jetbrains.kotlin</groupId>
 			<artifactId>kotlin-stdlib-jdk8</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-devtools</artifactId>
@@ -53,6 +52,12 @@
 					<artifactId>junit-vintage-engine</artifactId>
 				</exclusion>
 			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.awaitility</groupId>
+			<artifactId>awaitility</artifactId>
+			<version>4.0.3</version>
+			<scope>test</scope>
 		</dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -88,6 +93,7 @@
 						<version>${kotlin.version}</version>
 					</dependency>
 				</dependencies>
+
 			</plugin>
 		</plugins>
 	</build>

--- a/src/main/kotlin/com/ohmgeek/jukebox/queue/ConcurrentDistinctQueue.kt
+++ b/src/main/kotlin/com/ohmgeek/jukebox/queue/ConcurrentDistinctQueue.kt
@@ -1,0 +1,63 @@
+package com.ohmgeek.jukebox.queue
+
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.Executors
+
+class ConcurrentDistinctQueue<T> {
+    private val delegate = ConcurrentLinkedQueue<T>()
+    private val executor = Executors.newSingleThreadExecutor()
+
+    /**
+     * Add an element to the queue if it isn't already present.
+     *
+     * Note: this will execute asynchronously, so the element won't immediately be in the
+     * queue after adding (you'll need to wait).
+     *
+     * @param element : the element to add to the queue
+     */
+    fun add(element: T) {
+        // Here, we submit the addition to a thread pool.
+        // This will execute the addition and validation in a single block
+        // yielding atomicity.
+        executor.submit {
+            if (element !in delegate) {
+                delegate.add(element)
+            }
+        }
+    }
+
+    /**
+     * Get and remove the item at the top of the queue.
+     *
+     * @return element on the head of the queue
+     */
+    fun pop(): T {
+        return delegate.remove()
+    }
+
+    /**
+     * Remove a specific element from the queue.
+     *
+     * @param element : the item to remove
+     */
+    fun remove(element: T) {
+        delegate.run { remove(element) }
+    }
+
+    operator fun iterator(): MutableIterator<T> {
+        return delegate.iterator()
+    }
+
+    /**
+     * Return the element at the top of the queue, but don't remove it.
+     */
+    fun peek(): T {
+        return delegate.peek()
+    }
+
+    /**
+     * Get the number of unique items currently in the queue (not including values that are pending validation)
+     */
+    val size: Int
+        get() = delegate.size
+}

--- a/src/test/kotlin/com/ohmgeek/jukebox/queue/ConcurrentDistinctQueueTest.kt
+++ b/src/test/kotlin/com/ohmgeek/jukebox/queue/ConcurrentDistinctQueueTest.kt
@@ -1,0 +1,81 @@
+package com.ohmgeek.jukebox.queue
+
+import org.awaitility.Awaitility.await
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+internal class ConcurrentDistinctQueueTest {
+    private val sut = ConcurrentDistinctQueue<String>()
+
+    @Test
+    fun canAddElement() {
+        // Given a set of strings
+        val elem1 = "A"
+        val elem2 = "B"
+        val elem3 = "C"
+
+        // When we add them to the queue in order
+        sut.add(elem1)
+        sut.add(elem2)
+        sut.add(elem3)
+
+        // Then size should be three
+        awaitUntilSizeIs(3)
+
+        // Then Peek should display first element only
+        assertEquals(elem1, sut.peek())
+
+        // Then Pop should remove
+        assertEquals(elem1, sut.pop())
+        assertEquals(elem2, sut.pop())
+        assertEquals(elem3, sut.pop())
+    }
+
+    @Test
+    fun shouldAddElementOnceWhenAddingDuplicates() {
+        // Given a single element
+        val elem = "A"
+
+        // When we add several of the same elements at once
+        val threadPool = Executors.newFixedThreadPool(3)
+
+        threadPool.submit { sut.add(elem) }
+        threadPool.submit { sut.add(elem) }
+        threadPool.submit { sut.add(elem) }
+
+        // Then await for consistency (up to 3 seconds)
+        awaitUntilSizeIs(1)
+
+        // Verify only one element exists, and this is the the one added
+        assertEquals(sut.peek(), elem)
+        assertEquals(sut.size, 1)
+    }
+
+    @Test
+    fun canIterateOverEntireQueue() {
+        // Given a set of strings
+        val elements = listOf("A", "B", "C")
+
+        // When we add them to the queue in order
+        sut.add(elements[0])
+        sut.add(elements[1])
+        sut.add(elements[2])
+
+        awaitUntilSizeIs(3)
+
+        val iterator = sut.iterator()
+        for (elem in elements) {
+            assertEquals(elem, iterator.next())
+        }
+    }
+
+    private fun awaitUntilSizeIs(value: Int) {
+        await().dontCatchUncaughtExceptions().timeout(3, TimeUnit.SECONDS)
+                .until { sut.size == value }
+
+        // First, verify there are three items
+        assertEquals(value, sut.size)
+    }
+}


### PR DESCRIPTION
We need a data structure that is like a queue but has the following features:
- Additions undergo some check to verify the element to add isn't in the queue.
- The addition and validation should be atomic (ensuring users can't bypass these validation checks)
- Retrieving the state of the underlying data structure should be have an element of eventual consistency (excluding writes pending validation).